### PR TITLE
Define DEVELOPER_DIR variable, update PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 build/
+dist/
 *.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(xcshim VERSION 0.1)
+project(xcshim VERSION 0.1.1)
 
 set(PACKAGE_AUTHOR "Quamotion bvba")
 

--- a/src/10-xcshim.sh.in
+++ b/src/10-xcshim.sh.in
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Quamotion bvba
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# This file is part of xcode-shim @PROJECT_VERSION@
+#
+# Purpose: Set the DEVELOPER_DIR environment variable, and update the
+# PATH variable, so Appium can locate the Xcode shims
+
+export DEVELOPER_DIR="/usr/local/xcode"
+export PATH="${DEVELOPER_DIR}:${PATH}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ configure_file(xcodebuild.in xcodebuild @ONLY)
 configure_file(carthage.in carthage @ONLY)
 configure_file(xcrun.in xcrun @ONLY)
 configure_file(Info.plist.in Info.plist @ONLY)
+configure_file(10-xcshim.sh.in 10-xcshim.sh @ONLY)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xcodebuild DESTINATION ${xcode_dir})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xcrun DESTINATION ${xcode_dir})
@@ -12,3 +13,4 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/carthage DESTINATION ${xcode_dir})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Info.plist DESTINATION ${xcode_dir}/Contents/)
 install(DIRECTORY DESTINATION ${xcode_dir}/Contents/Developer)
 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/10-xcshim.sh DESTINATION etc/profile.d)


### PR DESCRIPTION
Appium uses the `DEVELOPER_DIR` environment variable to locate the directory in which Xcode is installed, and expects `xcrun` to be reachable from `PATH`.

Set these environment variables via a file in `/etc/profile.d/`