### PR TITLE
Fix paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(xcshim VERSION 0.1.2)
+project(xcshim VERSION 0.1.3)
 
 set(PACKAGE_AUTHOR "Quamotion bvba")
+set(CMAKE_INSTALL_PREFIX "/usr/local")
 
 add_subdirectory(src)
 

--- a/src/10-xcshim.sh.in
+++ b/src/10-xcshim.sh.in
@@ -11,5 +11,5 @@
 # Purpose: Set the DEVELOPER_DIR environment variable, and update the
 # PATH variable, so Appium can locate the Xcode shims
 
-export DEVELOPER_DIR="/usr/local/xcode"
+export DEVELOPER_DIR="@xcode_dir@"
 export PATH="${DEVELOPER_DIR}:${PATH}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,9 @@
-set (xcode_version 11.0)
-set (xcode_dir opt/xcode)
+set (etc_dir /etc)
 
-set (config_dir etc/quamotion)
+set (xcode_version 11.0)
+set (xcode_dir ${CMAKE_INSTALL_PREFIX}/opt/xcode)
+
+set (config_dir ${etc_dir}/quamotion)
 set (license_file ${config_dir}/.license)
 set (developer_profile_file ${config_dir}/quamotion.developerprofile)
 set (developer_profile_password quamotion)
@@ -21,4 +23,4 @@ install(DIRECTORY DESTINATION ${xcode_dir}/Contents/Developer)
 install(DIRECTORY DESTINATION ${config_dir})
 install(DIRECTORY DESTINATION ${developer_disk_dir})
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/10-xcshim.sh DESTINATION etc/profile.d)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/10-xcshim.sh DESTINATION ${etc_dir}/profile.d)


### PR DESCRIPTION
Configuration always goes into /etc (root)
All other folders (opt) are relative to $prefix
Default for $prefix is /usr/local